### PR TITLE
expose mk dependency container

### DIFF
--- a/src/Sushi.MediaKiwi.Vue/src/framework.ts
+++ b/src/Sushi.MediaKiwi.Vue/src/framework.ts
@@ -81,4 +81,6 @@ export * from "@/stores";
 
 export * from "@/router";
 
+export { container };
+
 import "@/assets/main.css";


### PR DESCRIPTION
expose the dependency container, because if you do 'import container from tsyringe' in the sample project, you get  a different instance and it does not have things like the axios instance
