### PR TITLE
changed view ID to varchar

### DIFF
--- a/src/Sushi.MediaKiwi.DAL/NavigationItem.cs
+++ b/src/Sushi.MediaKiwi.DAL/NavigationItem.cs
@@ -18,7 +18,7 @@ namespace Sushi.MediaKiwi.DAL
                 Map(x => x.Name, "Name");                
                 Map(x => x.SectionId, "SectionID");
                 Map(x => x.ParentNavigationItemId, "ParentNavigationItemID");
-                Map(x => x.ViewId, "ViewID");                
+                Map(x => x.ViewId, "ViewID").SqlType(System.Data.SqlDbType.VarChar);
             }
         }
         
@@ -26,6 +26,6 @@ namespace Sushi.MediaKiwi.DAL
         public string Name { get; set; }        
         public int SectionId { get; set; }  
         public int? ParentNavigationItemId { get; set; }
-        public int? ViewId { get; set; }        
+        public string? ViewId { get; set; }        
     }
 }

--- a/src/Sushi.MediaKiwi.DAL/Repository/IViewRepository.cs
+++ b/src/Sushi.MediaKiwi.DAL/Repository/IViewRepository.cs
@@ -20,20 +20,27 @@ namespace Sushi.MediaKiwi.DAL.Repository
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        Task<View?> GetAsync(int id);
+        Task<View?> GetAsync(string id);
 
         /// <summary>
-        /// Insert or updates a <see cref="View"/>.
+        /// Inserts a <see cref="View"/>.
         /// </summary>
         /// <param name="view"></param>
         /// <returns></returns>
-        Task SaveAsync(View view);
+        Task InsertAsync(View view);
+
+        /// <summary>
+        /// Updates a <see cref="View"/>.
+        /// </summary>
+        /// <param name="view"></param>
+        /// <returns></returns>
+        Task UpdateAsync(View view);
 
         /// <summary>
         /// Deletes a <see cref="View"/> by id.
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        Task DeleteAsync(int id);
+        Task DeleteAsync(string id);
     }
 }

--- a/src/Sushi.MediaKiwi.DAL/Repository/IViewRoleRepository.cs
+++ b/src/Sushi.MediaKiwi.DAL/Repository/IViewRoleRepository.cs
@@ -16,14 +16,14 @@ namespace Sushi.MediaKiwi.DAL.Repository
         /// Gets all <see cref="ViewRole"/> objects for the given filters.
         /// </summary>
         /// <returns></returns>
-        Task<QueryListResult<ViewRole>> GetAllAsync(int? viewId);
+        Task<QueryListResult<ViewRole>> GetAllAsync(string? viewId);
 
         /// <summary>
         /// Deletes all role assignments for a view.
         /// </summary>
         /// <param name="viewId"></param>
         /// <returns></returns>
-        Task DeleteForViewAsync(int viewId);
+        Task DeleteForViewAsync(string viewId);
 
         /// <summary>
         /// Inserts a role assignment.

--- a/src/Sushi.MediaKiwi.DAL/Repository/ViewRepository.cs
+++ b/src/Sushi.MediaKiwi.DAL/Repository/ViewRepository.cs
@@ -24,7 +24,7 @@ namespace Sushi.MediaKiwi.DAL.Repository
         }
 
         /// <inheritdoc/>    
-        public async Task DeleteAsync(int id)
+        public async Task DeleteAsync(string id)
         {
             var query = _connector.CreateQuery();
             query.Add(x => x.Id, id);
@@ -56,7 +56,7 @@ namespace Sushi.MediaKiwi.DAL.Repository
         }
 
         /// <inheritdoc/>    
-        public async Task<View?> GetAsync(int id)
+        public async Task<View?> GetAsync(string id)
         {
             var query = _connector.CreateQuery();
             query.Add(x => x.Id, id);
@@ -65,9 +65,15 @@ namespace Sushi.MediaKiwi.DAL.Repository
         }
 
         /// <inheritdoc/>    
-        public async Task SaveAsync(View view)
+        public async Task InsertAsync(View view)
         {
-            await _connector.SaveAsync(view);            
+            await _connector.InsertAsync(view);            
+        }
+
+        /// <inheritdoc/>    
+        public async Task UpdateAsync(View view)
+        {
+            await _connector.UpdateAsync(view);
         }
     }
 }

--- a/src/Sushi.MediaKiwi.DAL/Repository/ViewRoleRepository.cs
+++ b/src/Sushi.MediaKiwi.DAL/Repository/ViewRoleRepository.cs
@@ -21,7 +21,7 @@ namespace Sushi.MediaKiwi.DAL.Repository
         }
 
         /// <inheritdoc/>    
-        public async Task DeleteForViewAsync(int viewId)
+        public async Task DeleteForViewAsync(string viewId)
         {
             var query = _connector.CreateQuery();
 
@@ -30,10 +30,10 @@ namespace Sushi.MediaKiwi.DAL.Repository
         }
 
         /// <inheritdoc/>    
-        public async Task<QueryListResult<ViewRole>> GetAllAsync(int? viewId)
+        public async Task<QueryListResult<ViewRole>> GetAllAsync(string? viewId)
         {
             var query = _connector.CreateQuery();
-            if (viewId.HasValue)
+            if (viewId != null)
                 query.Add(x => x.ViewId, viewId);
             var result = await _connector.GetAllAsync(query);
             return result;

--- a/src/Sushi.MediaKiwi.DAL/View.cs
+++ b/src/Sushi.MediaKiwi.DAL/View.cs
@@ -14,9 +14,8 @@ namespace Sushi.MediaKiwi.DAL
         {
             public ViewMap()
             {
-                Table("mk_Views");
-                Id(x => x.Id, "ViewID");
-                Map(x => x.ExternalId, "ExternalID").SqlType(SqlDbType.VarChar);
+                Table("mk_Views");                
+                Id(x => x.Id, "ViewID").Assigned().SqlType(SqlDbType.VarChar);
                 Map(x => x.ComponentKey, "ComponentKey").SqlType(SqlDbType.VarChar);
                 Map(x => x.Name, "Name").SqlType(SqlDbType.NVarChar);                
                 Map(x => x.SectionId, "SectionID");
@@ -24,17 +23,15 @@ namespace Sushi.MediaKiwi.DAL
             }
         }
         
-        public int Id { get; set; }
         /// <summary>
         /// Gets or sets a human-readable unique ID.
         /// </summary>
-        public string ExternalId { get; set; }
+        public string Id { get; set; }                
         /// <summary>
         /// Gets or sets the key of the Vue component implementing this view, e.g. ./views/myView.vue, MyKey
         /// </summary>
         public string ComponentKey { get; set; }
-        public string Name { get; set; }
-        public string FilePath { get; set; }
+        public string Name { get; set; }        
         public int SectionId { get; set; }        
         public string? ParameterName { get; set; }
     }

--- a/src/Sushi.MediaKiwi.DAL/ViewRole.cs
+++ b/src/Sushi.MediaKiwi.DAL/ViewRole.cs
@@ -17,12 +17,12 @@ namespace Sushi.MediaKiwi.DAL
             public ViewRoleMap()
             {
                 Table("mk_ViewsRoles");
-                Id(x => x.ViewId, "ViewID").Assigned();
+                Id(x => x.ViewId, "ViewID").Assigned().SqlType(System.Data.SqlDbType.VarChar);
                 Id(x => x.Role, "RoleID").Assigned().SqlType(System.Data.SqlDbType.VarChar);
             }
         }
         
-        public int ViewId { get; set; }
+        public string ViewId { get; set; }
         public string Role { get; set; }
     }
 }

--- a/src/Sushi.MediaKiwi.SampleAPI/DAL/Hotel.cs
+++ b/src/Sushi.MediaKiwi.SampleAPI/DAL/Hotel.cs
@@ -14,7 +14,7 @@ namespace Sushi.MediaKiwi.SampleAPI.DAL
                 Map(x => x.IsActive, "IsActive");
                 Map(x => x.Name, "Name").SqlType(System.Data.SqlDbType.NVarChar).Length(256);
                 Map(x => x.CountryCode, "CountryCode").SqlType(System.Data.SqlDbType.Char).Length(2);
-                Map(x => x.Created, "Created");
+                Map(x => x.Created, "Created").ReadOnly();
                 Map(x => x.SRP.Currency, "SRP_Currency").SqlType(System.Data.SqlDbType.Char).Length(3);
                 Map(x => x.SRP.Amount, "SRP_Amount");
             }

--- a/src/Sushi.MediaKiwi.Services/Model/AutoMapperProfile.cs
+++ b/src/Sushi.MediaKiwi.Services/Model/AutoMapperProfile.cs
@@ -19,7 +19,7 @@ namespace Sushi.MediaKiwi.Services.Model
         {
             // from DAL to Model
             CreateMap<DAL.Section, Section>();
-            CreateMap<DAL.View, View>();
+            CreateMap<DAL.View, View>().ForMember(x=>x.Roles, o => o.Ignore());
             CreateMap<DAL.NavigationItem, NavigationItem>();
             CreateMap<DAL.Role, Role>();
 

--- a/src/Sushi.MediaKiwi.Services/Model/NavigationItem.cs
+++ b/src/Sushi.MediaKiwi.Services/Model/NavigationItem.cs
@@ -22,6 +22,6 @@ namespace Sushi.MediaKiwi.Services.Model
         
         public int? ParentNavigationItemId { get; set; }
         
-        public int? ViewId { get; set; }        
+        public string? ViewId { get; set; }        
     }
 }

--- a/src/Sushi.MediaKiwi.Services/Model/View.cs
+++ b/src/Sushi.MediaKiwi.Services/Model/View.cs
@@ -14,16 +14,10 @@ namespace Sushi.MediaKiwi.Services.Model
     public class View
     {
         /// <summary>
-        /// Unique identifier for this view.
-        /// </summary>
-        [SwaggerSchema(ReadOnly = true)]
-        public int Id { get; set; }
-
-        /// <summary>
         /// Human-readable unique ID.
         /// </summary>
-        [Required, StringLength(64)]
-        public string ExternalId { get; set; }
+        [SwaggerSchema(ReadOnly = true)]
+        public string? Id { get; set; }
 
         /// <summary>
         /// Name for this view.

--- a/src/Sushi.MediaKiwi.Vue/src/components/MkTable/MkTable.vue
+++ b/src/Sushi.MediaKiwi.Vue/src/components/MkTable/MkTable.vue
@@ -91,7 +91,7 @@
     // navigate user to target page if defined
     if (props.itemViewId) {
       // find navigation item for the view
-      const view = store.views.find((x) => x.externalId == props.itemViewId);
+      const view = store.views.find((x) => x.id == props.itemViewId);
 
       if (!view) {
         throw new Error(`No view found for external id ${props.itemViewId}`);
@@ -102,7 +102,7 @@
       }
 
       // push user to target page
-      navigation.navigateTo(navigationItem, 0);
+      navigation.navigateTo(navigationItem, undefined);
     }
   }
 

--- a/src/Sushi.MediaKiwi.Vue/src/components/MkTable/MkTableView.vue
+++ b/src/Sushi.MediaKiwi.Vue/src/components/MkTable/MkTableView.vue
@@ -42,7 +42,7 @@
     // navigate user to target page if defined
     if (props.itemViewId) {
       // find navigation item for the view
-      const view = store.views.find((x) => x.externalId == props.itemViewId);
+      const view = store.views.find((x) => x.id == props.itemViewId);
 
       if (!view) {
         throw new Error(`No view found for external id ${props.itemViewId}`);

--- a/src/Sushi.MediaKiwi.Vue/src/components/MkView/MkViewOverview.vue
+++ b/src/Sushi.MediaKiwi.Vue/src/components/MkView/MkViewOverview.vue
@@ -22,8 +22,8 @@
   const tableMap: TableMap<View> = {
     itemId: (x) => x.id,
     items: [
+      { headerTitle: "Id", value: (x) => x.id },
       { headerTitle: "Name", value: (x) => x.name, sortingOptions: { id: (x) => x.name } },
-      { headerTitle: "ExternalId", value: (x) => x.externalId },
       { headerTitle: "Section", value: (x) => sections.value.find((section) => section.id == x.sectionId)?.name },
       { headerTitle: "Component Key", value: (x) => x.componentKey },
       { headerTitle: "Parameter", value: (x) => x.parameterName },

--- a/src/Sushi.MediaKiwi.Vue/src/composables/useNavigation.ts
+++ b/src/Sushi.MediaKiwi.Vue/src/composables/useNavigation.ts
@@ -62,11 +62,6 @@ export function useNavigation() {
       if (navigationItem.view?.parameterName) {
         // if this is a dynamic route, try to resolve route parameter
         routeParams = {};
-
-        if (itemId === undefined) {
-          throw new Error(`Navigating to dynamic route but no itemId provided`);
-        }
-
         routeParams[navigationItem.view.parameterName] = itemId;
       }
 
@@ -130,7 +125,7 @@ export function useNavigation() {
     const navigationItem = currentNavigationItem.value;
     if (navigationItem.view?.parameterName) {
       // if this is a dynamic route, try to resolve route parameter
-      return route.params[navigationItem.view.parameterName];
+      return typeof route.params[navigationItem.view.parameterName] === "string" ? (route.params[navigationItem.view.parameterName] as string) : undefined;
     }
   });
 

--- a/src/Sushi.MediaKiwi.Vue/src/models/api/NavigationItem.ts
+++ b/src/Sushi.MediaKiwi.Vue/src/models/api/NavigationItem.ts
@@ -11,7 +11,7 @@ export interface NavigationItem {
   /** Id of the parent of this item in the navigation hierarchy. */
   parentNavigationItemId?: number;
   /** Identifier of the view to load when this navigation item is activated. If empty, the item is a folder. */
-  viewId?: number;
+  viewId?: string;
   /** Path, relative to the application's root. Not provided by API, but needs to be calculated based on item's hierarchy. */
   path: string;
   /** Parent item of this item in the navigation hierarchy. */

--- a/src/Sushi.MediaKiwi.Vue/src/models/api/View.ts
+++ b/src/Sushi.MediaKiwi.Vue/src/models/api/View.ts
@@ -1,7 +1,6 @@
 export interface View {
-  id: number;
   /** Human-readable unique ID. */
-  externalId?: string;
+  id: string;
   /** Name for this screen, can be used for display purposes. */
   name?: string;
   /** Unique key for the screen's component. Will be used to find a match in the modules provided when installing MediaKiwi */

--- a/src/Sushi.MediaKiwi.Vue/src/services/IViewConnector.ts
+++ b/src/Sushi.MediaKiwi.Vue/src/services/IViewConnector.ts
@@ -3,9 +3,9 @@ import { View } from "@/models";
 import { Paging } from "@/models/api/Paging";
 
 export interface IViewConnector {
-  CreateView(request: View): Promise<View>;
-  DeleteView(id: number): Promise<void>;
+  CreateView(id: string, request: View): Promise<View>;
+  DeleteView(id: string): Promise<void>;
   GetViews(sectionId?: number, paging?: Paging, sorting?: Sorting): Promise<ListResult<View>>;
-  GetView(id: number): Promise<View | undefined>;
-  UpdateView(id: number, request: View): Promise<View>;
+  GetView(id: string): Promise<View | undefined>;
+  UpdateView(id: string, request: View): Promise<View>;
 }

--- a/src/Sushi.MediaKiwi.Vue/src/services/ViewConnector.ts
+++ b/src/Sushi.MediaKiwi.Vue/src/services/ViewConnector.ts
@@ -9,12 +9,12 @@ import type { AxiosInstance } from "axios";
 export class ViewConnector implements IViewConnector {
   constructor(@inject("MediakiwiAxiosInstance") private axios: AxiosInstance) {}
 
-  async CreateView(request: View): Promise<View> {
-    const response = await this.axios.post<View>(`/views`, request);
+  async CreateView(id: string, request: View): Promise<View> {
+    const response = await this.axios.post<View>(`/views/${id}`, request);
     return response.data;
   }
 
-  async DeleteView(id: number): Promise<void> {
+  async DeleteView(id: string): Promise<void> {
     await this.axios.delete(`/views/${id}`);
   }
 
@@ -29,12 +29,12 @@ export class ViewConnector implements IViewConnector {
     return response.data;
   }
 
-  async GetView(id: number): Promise<View | undefined> {
+  async GetView(id: string): Promise<View | undefined> {
     const response = await this.axios.get<View>(`/views/${id}`);
     return response.data;
   }
 
-  async UpdateView(id: number, request: View): Promise<View> {
+  async UpdateView(id: string, request: View): Promise<View> {
     const response = await this.axios.put<View>(`/views/${id}`, request);
     return response.data;
   }

--- a/src/Sushi.MediaKiwi.Vue/src/stores/index.ts
+++ b/src/Sushi.MediaKiwi.Vue/src/stores/index.ts
@@ -111,7 +111,7 @@ export const useMediakiwiStore = defineStore({
       let result = parentPath + `/${encodeURI(navigationItem.name)}`;
       // if dynamic, add parameter
       if (navigationItem.view?.parameterName) {
-        result += `/:${navigationItem.view.parameterName}`;
+        result += `/:${navigationItem.view.parameterName}?`;
       }
       return result;
     },

--- a/src/Sushi.MediaKiwi.WebAPI/ViewController.cs
+++ b/src/Sushi.MediaKiwi.WebAPI/ViewController.cs
@@ -36,7 +36,7 @@ namespace Sushi.MediaKiwi.WebAPI
         /// <returns></returns>
         [HttpDelete]
         [Route("{id}")]
-        public async Task<ActionResult<View>> DeleteView(int id)
+        public async Task<ActionResult<View>> DeleteView(string id)
         {
             var result = await _viewService.DeleteAsync(id);
             return this.CreateResponse(result);
@@ -66,7 +66,7 @@ namespace Sushi.MediaKiwi.WebAPI
         /// <returns></returns>
         [HttpGet]
         [Route("{id}")]
-        public async Task<ActionResult<View>> GetView(int id)
+        public async Task<ActionResult<View>> GetView(string id)
         {
             var result = await _viewService.GetAsync(id);
             return this.CreateResponse(result);
@@ -74,13 +74,13 @@ namespace Sushi.MediaKiwi.WebAPI
 
         /// <summary>
         /// Creates a new view.
-        /// </summary>
-        /// <param name="request"></param>
+        /// </summary>        
         /// <returns></returns>
         [HttpPost]
-        public async Task<ActionResult<View>> CreateView(View request)
+        [Route("{id}")]
+        public async Task<ActionResult<View>> CreateView(string id, View request)
         {
-            var result = await _viewService.SaveAsync(null, request);
+            var result = await _viewService.CreateAsync(id, request);
             return this.CreateResponse(result);
         }
 
@@ -90,9 +90,9 @@ namespace Sushi.MediaKiwi.WebAPI
         /// <returns></returns>
         [HttpPut]
         [Route("{id}")]
-        public async Task<ActionResult<View>> UpdateView(int id, View request)
+        public async Task<ActionResult<View>> UpdateView(string id, View request)
         {
-            var result = await _viewService.SaveAsync(id, request);
+            var result = await _viewService.UpdateAsync(id, request);
             return this.CreateResponse(result);
         }
     }

--- a/tests/Sushi.MediaKiwi.DAL.ManualTests/ViewRepositoryTest.cs
+++ b/tests/Sushi.MediaKiwi.DAL.ManualTests/ViewRepositoryTest.cs
@@ -39,10 +39,10 @@ namespace Sushi.MediaKiwi.DAL.ManualTests
         [Fact]
         public async Task GetOneTest()
         {
-            var view = await _repository.GetAsync(1);
+            var view = await _repository.GetAsync("Home");
 
             Assert.NotNull(view);
-            Assert.Equal(1, view.Id);
+            Assert.Equal("Home", view.Id);
         }
     }
 }

--- a/tests/Sushi.MediaKiwi.Services.UnitTests/AutoMapperProfileTest.cs
+++ b/tests/Sushi.MediaKiwi.Services.UnitTests/AutoMapperProfileTest.cs
@@ -1,0 +1,19 @@
+﻿using AutoMapper;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sushi.MediaKiwi.Services.UnitTests
+{
+    public class AutoMapperProfileTest
+    {
+        [Fact]
+        public void AutoMapperProfileTest_ConfigurationIsValid()
+        {
+            var config = new MapperConfiguration(cfg => cfg.AddProfile<Model.AutoMapperProfile>());
+            config.AssertConfigurationIsValid();
+        }
+    }
+}

--- a/tests/Sushi.MediaKiwi.Services.UnitTests/ViewServiceTest.cs
+++ b/tests/Sushi.MediaKiwi.Services.UnitTests/ViewServiceTest.cs
@@ -30,7 +30,7 @@ namespace Sushi.MediaKiwi.Services.UnitTests
             // arrange
             var viewStub = new DAL.View()
             {
-                Id = 11
+                Id = "abc"
             };
 
             var viewRepositoryMock = new Mock<IViewRepository>();
@@ -55,13 +55,13 @@ namespace Sushi.MediaKiwi.Services.UnitTests
             // arrange
             DAL.View? viewStub = null;
             var viewRepositoryMock = new Mock<IViewRepository>();
-            viewRepositoryMock.Setup(x => x.GetAsync(It.IsAny<int>())).ReturnsAsync(viewStub);
+            viewRepositoryMock.Setup(x => x.GetAsync(It.IsAny<string>())).ReturnsAsync(viewStub);
             var viewRoleRepositoryMock = new Mock<IViewRoleRepository>();
 
             var service = new ViewService(viewRepositoryMock.Object, viewRoleRepositoryMock.Object, _mapper);
 
             // act
-            var result = await service.DeleteAsync(17);
+            var result = await service.DeleteAsync("abc");
 
             // assert
             Assert.NotNull(result);
@@ -126,18 +126,18 @@ namespace Sushi.MediaKiwi.Services.UnitTests
             // arrange
             var viewStubs = new QueryListResult<DAL.View>
             {
-                new DAL.View() { Id = 1 },
-                new DAL.View() { Id = 2 }
+                new DAL.View() { Id = "abc" },
+                new DAL.View() { Id = "def" }
             };
             var roleStubs = new QueryListResult<DAL.ViewRole>
             {
-                new DAL.ViewRole() { ViewId = 1, Role = "Admin" }
+                new DAL.ViewRole() { ViewId = "abc", Role = "Admin" }
             };
 
             var viewRepositoryMock = new Mock<IViewRepository>();
             viewRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<int?>(), It.IsAny<PagingValues>(), null)).ReturnsAsync(viewStubs);
             var viewRoleRepositoryMock = new Mock<IViewRoleRepository>();
-            viewRoleRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<int?>())).ReturnsAsync(roleStubs);
+            viewRoleRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<string?>())).ReturnsAsync(roleStubs);
 
             var service = new ViewService(viewRepositoryMock.Object, viewRoleRepositoryMock.Object, _mapper);
 
@@ -145,8 +145,8 @@ namespace Sushi.MediaKiwi.Services.UnitTests
             var result = await service.GetAllAsync(null, PagingValues.Default);
 
             // assert            
-            var view1 = result.Value.Result.First(x => x.Id == 1);
-            var view2 = result.Value.Result.First(x => x.Id == 2);
+            var view1 = result.Value.Result.First(x => x.Id == "abc");
+            var view2 = result.Value.Result.First(x => x.Id == "def");
             Assert.Equal(ResultCode.Success, result.Code);
             Assert.Single(view1.Roles);
             Assert.Empty(view2.Roles);
@@ -159,17 +159,17 @@ namespace Sushi.MediaKiwi.Services.UnitTests
             // arrange
             var viewStub = new DAL.View()
             {
-                Id = 11
+                Id = "abc"
             };                
 
             var viewRepositoryMock = new Mock<IViewRepository>();
-            viewRepositoryMock.Setup(x => x.GetAsync(It.Is<int>(x=>x == viewStub.Id))).ReturnsAsync(viewStub);
+            viewRepositoryMock.Setup(x => x.GetAsync(It.Is<string>(x=>x == viewStub.Id))).ReturnsAsync(viewStub);
             var viewRoleRepositoryMock = new Mock<IViewRoleRepository>();
-            viewRoleRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<int>())).ReturnsAsync(new QueryListResult<DAL.ViewRole>());
+            viewRoleRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<string>())).ReturnsAsync(new QueryListResult<DAL.ViewRole>());
             var service = new ViewService(viewRepositoryMock.Object, viewRoleRepositoryMock.Object, _mapper);
 
             // act
-            var result = await service.GetAsync(11);
+            var result = await service.GetAsync("abc");
 
             // assert
             Assert.NotNull(result);
@@ -184,13 +184,13 @@ namespace Sushi.MediaKiwi.Services.UnitTests
             // arrange
             DAL.View? viewStub = null;
             var viewRepositoryMock = new Mock<IViewRepository>();
-            viewRepositoryMock.Setup(x => x.GetAsync(It.IsAny<int>())).ReturnsAsync(viewStub);
+            viewRepositoryMock.Setup(x => x.GetAsync(It.IsAny<string>())).ReturnsAsync(viewStub);
             var viewRoleRepositoryMock = new Mock<IViewRoleRepository>();
 
             var service = new ViewService(viewRepositoryMock.Object, viewRoleRepositoryMock.Object, _mapper);
 
             // act
-            var result = await service.DeleteAsync(17);
+            var result = await service.DeleteAsync("def");
 
             // assert
             Assert.NotNull(result);
@@ -198,39 +198,19 @@ namespace Sushi.MediaKiwi.Services.UnitTests
         }
 
         [Fact]
-        public async Task SaveViewTest_NotFound()
-        {
-            // arrange
-            DAL.View? viewStub = null;
-            var viewRepositoryMock = new Mock<IViewRepository>();
-            viewRepositoryMock.Setup(x => x.GetAsync(It.IsAny<int>())).ReturnsAsync(viewStub);
-            var viewRoleRepositoryMock = new Mock<IViewRoleRepository>();
-
-            var service = new ViewService(viewRepositoryMock.Object, viewRoleRepositoryMock.Object, _mapper);
-
-            // act
-            var result = await service.SaveAsync(17, new View());
-
-            // assert
-            Assert.NotNull(result);
-            Assert.Equal(ResultCode.NotFound, result.Code);
-        }
-
-        [Fact]
-        public async Task SaveViewTest_Create()
+        public async Task CreateViewTest()
         {
             // arrange
             var view = new View()
             {
-                ComponentKey = "comp",
-                ExternalId = "123",
+                Id = "value to be ignored",
+                ComponentKey = "comp",                
                 Name = "name",
                 Roles = new List<string>() { "Admin", "User" },
                 SectionId = 2
             };
 
-
-            int newId = 12;
+            string newId = "abc";
             var dalResult = new DAL.View() { Id = newId };
 
             var roleStubs = new QueryListResult<DAL.ViewRole>
@@ -240,40 +220,42 @@ namespace Sushi.MediaKiwi.Services.UnitTests
             };
 
             var viewRepositoryMock = new Mock<IViewRepository>();
-            viewRepositoryMock.Setup(x => x.SaveAsync(It.IsAny<DAL.View>())).Callback<DAL.View>(x => x.Id = newId);
+            viewRepositoryMock.Setup(x => x.InsertAsync(It.Is<DAL.View>(x=>x.Id == newId))).Callback<DAL.View>(x => x.Id = newId);
             var viewRoleRepositoryMock = new Mock<IViewRoleRepository>();
-            viewRoleRepositoryMock.Setup(x => x.DeleteForViewAsync(It.IsAny<int>())).Verifiable();
+            viewRoleRepositoryMock.Setup(x => x.DeleteForViewAsync(It.IsAny<string>())).Verifiable();
             viewRoleRepositoryMock.Setup(x => x.InsertAsync(It.IsAny<DAL.ViewRole>())).Verifiable();
-            viewRoleRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<int?>())).ReturnsAsync(roleStubs);
+            viewRoleRepositoryMock.Setup(x => x.GetAllAsync(It.Is<string?>(x => x == newId))).ReturnsAsync(roleStubs);
 
             var service = new ViewService(viewRepositoryMock.Object, viewRoleRepositoryMock.Object, _mapper);
 
             // act
-            var result = await service.SaveAsync(null, view);
+            var result = await service.CreateAsync(newId, view);
 
             Assert.NotNull(result);
             Assert.Equal(ResultCode.Success, result.Code);
             Assert.NotNull(result.Value);
             Assert.Equal(newId, result.Value.Id);
-            viewRoleRepositoryMock.Verify(x => x.DeleteForViewAsync(It.IsAny<int>()), Times.Never);
+            viewRoleRepositoryMock.Verify(x => x.DeleteForViewAsync(It.IsAny<string>()), Times.Never);
             viewRoleRepositoryMock.Verify(x => x.InsertAsync(It.IsAny<DAL.ViewRole>()), Times.Exactly(2));
         }
 
+        
+
         [Fact]
-        public async Task SaveViewTest_Update()
+        public async Task UpdateViewTest()
         {
             // arrange
             var view = new View()
             {
-                ComponentKey = "comp",
-                ExternalId = "123",
+                Id = "value to be ignored",
+                ComponentKey = "comp",                
                 Name = "name",
                 Roles = new List<string>() { "Admin", "User" },
                 SectionId = 2
             };
 
 
-            int existingId = 17;
+            string existingId = "xyz";
             var dalResult = new DAL.View() { Id = existingId };
 
             var roleStubs = new QueryListResult<DAL.ViewRole>
@@ -284,27 +266,44 @@ namespace Sushi.MediaKiwi.Services.UnitTests
 
             var viewRepositoryMock = new Mock<IViewRepository>();
             viewRepositoryMock.Setup(x => x.GetAsync(existingId)).ReturnsAsync(dalResult).Verifiable();
-            viewRepositoryMock.Setup(x => x.SaveAsync(dalResult)).Verifiable();
+            viewRepositoryMock.Setup(x => x.UpdateAsync(dalResult)).Verifiable();
             var viewRoleRepositoryMock = new Mock<IViewRoleRepository>();
-            viewRoleRepositoryMock.Setup(x => x.DeleteForViewAsync(It.IsAny<int>())).Verifiable();
+            viewRoleRepositoryMock.Setup(x => x.DeleteForViewAsync(It.IsAny<string>())).Verifiable();
             viewRoleRepositoryMock.Setup(x => x.InsertAsync(It.IsAny<DAL.ViewRole>())).Verifiable();
-            viewRoleRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<int?>())).ReturnsAsync(roleStubs);
+            viewRoleRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<string?>())).ReturnsAsync(roleStubs);
 
             var service = new ViewService(viewRepositoryMock.Object, viewRoleRepositoryMock.Object, _mapper);
 
             // act
-            var result = await service.SaveAsync(existingId, view);
+            var result = await service.UpdateAsync(existingId, view);
 
             Assert.NotNull(result);
             Assert.Equal(ResultCode.Success, result.Code);
             Assert.NotNull(result.Value);
             Assert.Equal(existingId, result.Value.Id);
             viewRepositoryMock.Verify(x=>x.GetAsync(existingId), Times.Once);
-            viewRepositoryMock.Verify(x=>x.SaveAsync(dalResult), Times.Once);
-            viewRoleRepositoryMock.Verify(x => x.DeleteForViewAsync(It.IsAny<int>()), Times.Once);
+            viewRepositoryMock.Verify(x=>x.UpdateAsync(dalResult), Times.Once);
+            viewRoleRepositoryMock.Verify(x => x.DeleteForViewAsync(It.IsAny<string>()), Times.Once);
             viewRoleRepositoryMock.Verify(x => x.InsertAsync(It.IsAny<DAL.ViewRole>()), Times.Exactly(2));
         }
 
+        [Fact]
+        public async Task UpdateViewTest_NotFound()
+        {
+            // arrange
+            DAL.View? viewStub = null;
+            var viewRepositoryMock = new Mock<IViewRepository>();
+            viewRepositoryMock.Setup(x => x.GetAsync(It.IsAny<string>())).ReturnsAsync(viewStub);
+            var viewRoleRepositoryMock = new Mock<IViewRoleRepository>();
 
+            var service = new ViewService(viewRepositoryMock.Object, viewRoleRepositoryMock.Object, _mapper);
+
+            // act
+            var result = await service.UpdateAsync("jkl", new View());
+
+            // assert
+            Assert.NotNull(result);
+            Assert.Equal(ResultCode.NotFound, result.Code);
+        }
     }
 }


### PR DESCRIPTION
made view.ID a human readable string:
- allows cross environment referencing (ie. DEV, TST, ACC, PRD to share the same ID)
- allows use of View.ID as translation namespace for localizing resources per view
- View already contained an 'ExternalID', which was used in front-end code. This made the identity column redundant, as this user assigned external id was already a valid primary key candidate