### PR TITLE
Added msal scope with clientId from mk options

### DIFF
--- a/src/Sushi.MediaKiwi.Vue/package.json
+++ b/src/Sushi.MediaKiwi.Vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supershift/mediakiwi-vue",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "description": "Vue 3 Library for the MediaKiwi Portal Builder",
   "scripts": {
     "build": "vite build --mode development",

--- a/src/Sushi.MediaKiwi.Vue/src/framework.ts
+++ b/src/Sushi.MediaKiwi.Vue/src/framework.ts
@@ -67,6 +67,9 @@ export default {
 
     // create msal instance and install plugin
     identity.msalInstance = new PublicClientApplication(options.msalConfig);
+    // add api scope to msal instance
+    identity.scopes = [`api://${options.msalConfig.auth.clientId}/access_via_approle_assignments`];
+    // install msal plugin
     app.use(msalPlugin, identity.msalInstance);
 
     // get default router options

--- a/src/Sushi.MediaKiwi.Vue/src/identity/index.ts
+++ b/src/Sushi.MediaKiwi.Vue/src/identity/index.ts
@@ -7,7 +7,6 @@ export const identity = <
     getAccessToken: () => Promise<string | undefined>;
   }
 >{
-  scopes: ["api://7cd2eddb-b79e-4e04-ac24-0011821ccb8e/access_via_approle_assignments"],
   getAccessToken: async (): Promise<string | undefined> => {
     let result: string | undefined = undefined;
     const account = identity.msalInstance.getActiveAccount();


### PR DESCRIPTION
Bumped to version 0.1.0-beta.3
Removed hardcoded api scope for msal and added computed url based on the clientId form the configuration options