### PR TITLE
Added New MkNavigationDrawerInfo component

### DIFF
--- a/src/Sushi.MediaKiwi.Vue/sample/views/Hotels/HotelEdit.vue
+++ b/src/Sushi.MediaKiwi.Vue/sample/views/Hotels/HotelEdit.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { MkForm, MkMoneyValue, MkFileInput } from "@/components";
-  import { useNavigation, useValidationRules, useBreadcrumbs } from "@/composables";
+  import { useNavigation, useValidationRules, useBreadcrumbs, useI18next } from "@/composables";
 
   import { HotelConnector } from "./../../services/HotelConnector";
   import { CountryConnector } from "./../../services/CountryConnector";
@@ -9,6 +9,7 @@
   import { Hotel } from "./../../models/Hotel";
   import { container } from "tsyringe";
   import { Country } from "./../../models/Country";
+  import MkNavigationDrawerInfo from "@/components/MkNavigation/MkNavigationDrawerInfo.vue";
 
   // inject dependencies
   const hotelConnector = container.resolve(HotelConnector);
@@ -16,6 +17,7 @@
   const { required } = useValidationRules();
   const fileUploadConnector = container.resolve(FileUploadConnector);
   const { setCustomPageTitle } = useBreadcrumbs();
+  const { formatDateTime } = await useI18next();
 
   const navigation = useNavigation();
   const radioModel = ref("1");
@@ -103,6 +105,18 @@
 </script>
 
 <template>
+  <MkNavigationDrawerInfo>
+    <v-card variant="flat" rounded="lg">
+      <v-card-title>{{ state.hotel.name }}</v-card-title>
+      <v-card-text>
+        <v-img
+          src="https://plus.unsplash.com/premium_photo-1678297269980-16f4be3a15a6?q=80&w=300&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+        />
+      </v-card-text>
+      <v-card-text> Located in: {{ state.hotel.countryCode }} </v-card-text>
+    </v-card>
+  </MkNavigationDrawerInfo>
+
   <MkForm title="Hotel edit" @save="onSave" @undo="onUndo" @delete="onDelete" @load="onLoad">
     <template #toolbarHeader>
       <v-card-text class="flex-1-1 w-75"> Hotel edit </v-card-text>

--- a/src/Sushi.MediaKiwi.Vue/src/components/MkNavigation/MkNavigationDrawer.vue
+++ b/src/Sushi.MediaKiwi.Vue/src/components/MkNavigation/MkNavigationDrawer.vue
@@ -23,6 +23,9 @@
         :prepend-icon="IconsLibrary.arrowLeft"
         @click.stop="navigateTo(currentRootItem)"
       />
+
+      <div id="navigationDrawerInfo" class="mb-4"></div>
+
       <mk-navigation-item
         v-for="item in getItemsBasedOnRoot()"
         :key="item.id"

--- a/src/Sushi.MediaKiwi.Vue/src/components/MkNavigation/MkNavigationDrawerInfo.vue
+++ b/src/Sushi.MediaKiwi.Vue/src/components/MkNavigation/MkNavigationDrawerInfo.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts"></script>
+<template>
+  <teleport to="#navigationDrawerInfo">
+    <slot></slot>
+  </teleport>
+</template>


### PR DESCRIPTION
Added MkNavigationDrawerInfo component to be used on a view to teleport UI to the Navigation Drawer

Example in HotelEdit.vue
```js
 <MkNavigationDrawerInfo>
    <v-card variant="flat" rounded="lg">
      <v-card-title>{{ state.hotel.name }}</v-card-title>
      <v-card-text>
        <v-img
          src="[some-image-url]"
        />
      </v-card-text>
      <v-card-text> Located in: {{ state.hotel.countryCode }} </v-card-text>
    </v-card>
  </MkNavigationDrawerInfo>
```

![image](https://github.com/Supershift/Sushi.MediaKiwi2/assets/18422683/10607bac-b58c-46cf-b6cb-053851709462)
