### PR TITLE
Remove existing paging parameters before adding a new

### DIFF
--- a/src/Sushi.MediaKiwi.WebAPI/Paging/PagingSwaggerFilter.cs
+++ b/src/Sushi.MediaKiwi.WebAPI/Paging/PagingSwaggerFilter.cs
@@ -31,7 +31,7 @@ namespace Sushi.MediaKiwi.WebAPI.Paging
                         operation.Parameters = new List<OpenApiParameter>();
                     }
 
-                    var pagingParameter = operation.Parameters.FirstOrDefault(x => x.Name == "paging");
+                    var pagingParameter = operation.Parameters.FirstOrDefault(x => x.Schema.Reference?.Id == nameof(PagingValues));
                     if (pagingParameter is not null)
                     {
                         operation.Parameters.Remove(pagingParameter);


### PR DESCRIPTION
Remove existing paging parameters before adding a new one to avoid duplicate paging in swagger