### PR TITLE
Update MkDisplayOptions flow

### DIFF
--- a/src/Sushi.MediaKiwi.Vue/src/components/MkDisplayOptions/MkDisplayOptions.vue
+++ b/src/Sushi.MediaKiwi.Vue/src/components/MkDisplayOptions/MkDisplayOptions.vue
@@ -3,12 +3,17 @@
   import { useTableDisplayOptions } from "@/composables/useTableDisplayOptions";
   import { useSnackbarStore } from "@/stores";
   import { useI18next } from "@/composables/useI18next";
-  import { computed } from "vue";
+  import { computed, reactive } from "vue";
 
   // inject dependencies
   const { setColumnVisibility } = useTableDisplayOptions();
   const snackbar = useSnackbarStore();
   const { defaultT } = await useI18next("MKDisplayOptions");
+
+  const state = reactive({
+    menuState: false,
+    isEdited: false,
+  });
 
   /** Display Options */
   const displayOptions = defineModel<TableColumn[] | boolean>("displayOptions", { required: false, default: [] });
@@ -22,15 +27,24 @@
    * @param column table columns to update
    */
   function updateDisplayColumns(column: TableColumn) {
+    state.isEdited = true;
     // Update the visibility of the columns when the user changes the options in the list
     setColumnVisibility(displayOptions.value as TableColumn[], column, tableReference.value);
-    // Notify the user
-    snackbar.showMessage(defaultT.value("DisplayOptionsVisibilityChanged", "The visibility of the columns has been adjusted."));
+  }
+
+  function onModelStateChange(value: boolean) {
+    if (!value && state.isEdited) {
+      // Notify the user
+      snackbar.showMessage(defaultT.value("DisplayOptionsVisibilityChanged", "The visibility of the columns has been adjusted."));
+    } else {
+      // Reset the state
+      state.isEdited = false;
+    }
   }
 </script>
 <template>
   <div class="mk-display-options">
-    <v-menu close-on-content-click v-if="hasDisplayOptions">
+    <v-menu v-if="hasDisplayOptions" v-model="state.menuState" @update:model-value="onModelStateChange" :close-on-back="false" :close-on-content-click="false">
       <!-- Button -->
       <template #activator="args">
         <v-btn v-bind="args.props" variant="text" class="mk-display-options__button">
@@ -39,7 +53,7 @@
       </template>
       <v-list class="mk-display-options__list">
         <v-list-item v-for="column in loadedColumns" :key="column.index" class="mk-display-options__list-item">
-          <v-checkbox v-model="column.visible" @update:modelValue="updateDisplayColumns(column)" :label="column.name"></v-checkbox>
+          <v-checkbox v-model="column.visible" @update:modelValue="updateDisplayColumns(column)" :label="column.name" hide-details></v-checkbox>
         </v-list-item>
       </v-list>
     </v-menu>


### PR DESCRIPTION
Updated so the DisplayOptions menu remains open while editing, and only throw a snackbar message when closing and items have been changed