### PR TITLE
Bump Microsoft.Identity.Web to 3.8.3

### DIFF
--- a/src/Sushi.MediaKiwi.WebAPI/Sushi.MediaKiwi.WebAPI.csproj
+++ b/src/Sushi.MediaKiwi.WebAPI/Sushi.MediaKiwi.WebAPI.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="3.8.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Microsoft.Identity.Web to 3.8.0 has a vulnerability. Required upgrade to 3.8.3