### PR TITLE
Set vuetify on a fixed version

### DIFF
--- a/src/Sushi.MediaKiwi.Vue/package-lock.json
+++ b/src/Sushi.MediaKiwi.Vue/package-lock.json
@@ -14,9 +14,9 @@
         "@vueuse/components": "^12.0.0",
         "@vueuse/core": "^12.0.0",
         "axios": "^1.7.7",
-        "i18next": "^23.16.8 ",
+        "i18next": "^25.0.0",
         "i18next-browser-languagedetector": "^8.0.0",
-        "i18next-http-backend": "^2.7.3",
+        "i18next-http-backend": "^3.0.2",
         "luxon": "^3.5.0",
         "material-symbols": "^0.28.2",
         "pinia": "^2.3.1",
@@ -68,7 +68,7 @@
         "vue": "^3.5.13",
         "vue-eslint-parser": "^9.3.2",
         "vue-tsc": "^2.2.0",
-        "vuetify": "^3.7.4",
+        "vuetify": "3.7.19",
         "webfontloader": "^1.6.28"
       },
       "engines": {
@@ -8833,9 +8833,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "23.16.8",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
-      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.0.1.tgz",
+      "integrity": "sha512-8S8PyZbrymJZn3DaN70/34JYWNhsqrU6yA4MuzcygJBv+41dgNMocEA8h+kV1P7MCc1ll03lOTOIXE7mpNCicw==",
       "funding": [
         {
           "type": "individual",
@@ -8852,7 +8852,15 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.2"
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/i18next-browser-languagedetector": {
@@ -8865,9 +8873,9 @@
       }
     },
     "node_modules/i18next-http-backend": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.7.3.tgz",
-      "integrity": "sha512-FgZxrXdRA5u44xfYsJlEBL4/KH3f2IluBpgV/7riW0YW2VEyM8FzVt2XHAOi6id0Ppj7vZvCZVpp5LrGXnc8Ig==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.2.tgz",
+      "integrity": "sha512-PdlvPnvIp4E1sYi46Ik4tBYh/v/NbYfFFgTjkwFl0is8A18s7/bx9aXqsrOax9WUbeNS6mD2oix7Z0yGGf6m5g==",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "4.0.0"
@@ -15190,9 +15198,9 @@
       "license": "MIT"
     },
     "node_modules/vuetify": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.8.1.tgz",
-      "integrity": "sha512-3qReKBBWIIdJJmwnFU1blVIKHDtnLfIP7kk0MwUrrfjYkWmsDpsymtDnsukkTCnlJ1WvhLr64eQFosr0RVbj9w==",
+      "version": "3.7.19",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.19.tgz",
+      "integrity": "sha512-RrUpdBOGWGcT2oNLqXBiqYRudKTFqxTfr8lISl51Cuo80cfgRmbyDnlQQRWxE4QSNxcqXk6ZzBoJRUEXpW9C/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15204,9 +15212,9 @@
       },
       "peerDependencies": {
         "typescript": ">=4.7",
-        "vite-plugin-vuetify": ">=2.1.0",
-        "vue": "^3.5.0",
-        "webpack-plugin-vuetify": ">=3.1.0"
+        "vite-plugin-vuetify": ">=1.0.0",
+        "vue": "^3.3.0",
+        "webpack-plugin-vuetify": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/src/Sushi.MediaKiwi.Vue/package.json
+++ b/src/Sushi.MediaKiwi.Vue/package.json
@@ -104,7 +104,7 @@
     "vue": "^3.5.13",
     "vue-eslint-parser": "^9.3.2",
     "vue-tsc": "^2.2.0",
-    "vuetify": "^3.7.4",
+    "vuetify": "3.7.19",
     "webfontloader": "^1.6.28"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Set vuetify on a fixed version, when updating to 3.8.x we'll need to some reviews.
Package and package lock has some mismatches. those are resolve automatically, needs to be cautious with that.

Datepicker styles broke due to: https://github.com/vuetifyjs/vuetify/commit/64fae35b9e72eacdb863e82cf1998bedbbd5527c